### PR TITLE
User may create and edit sales

### DIFF
--- a/app/controllers/sales_controller.rb
+++ b/app/controllers/sales_controller.rb
@@ -3,6 +3,12 @@
 class SalesController < ApplicationController # :nodoc:
   include SimpleCrudController
 
+  permitted_params :customer_id,
+                   :item_id,
+                   :sales_date,
+                   :sales_quantity,
+                   :unit_of_measure_id
+
   private
 
   def render_show(sale)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,4 +12,8 @@ class Item < ApplicationRecord # :nodoc:
             :item_number,
             :unit_of_measure,
             presence: true
+
+  def full_item_description
+    [item_number, '-', item_description].join(' ')
+  end
 end

--- a/app/views/sales/_form.html.erb
+++ b/app/views/sales/_form.html.erb
@@ -1,0 +1,33 @@
+<%= simple_form_for(sale,
+                    wrapper: :horizontal_form) do |form| %>
+  <%= form.association :customer,
+                       label: false,
+                       label_method: :name,
+                       prompt: :translate,
+                       value_method: :id %>
+  <%= form.association :item,
+                       label: false,
+                       label_method: :full_item_description,
+                       prompt: :translate,
+                       value_method: :id %>
+  <%= form.association :unit_of_measure,
+                       label: false,
+                       label_method: :code,
+                       prompt: :translate,
+                       value_method: :id %>
+  <%= form.input :sales_date,
+                 as: :date,
+                 html5: true,
+                 label: false %>
+  <%= form.input :sales_quantity,
+                 label: false,
+                 prompt: :translate %>
+  <div class='float-left'>
+    <%= form.button :submit,
+                    t('shared.buttons.save'),
+                    class: 'btn btn-primary' %>
+    <%= link_to t('shared.buttons.back'),
+                sales_path,
+                class: 'btn btn-outline-secondary ml-2' %>
+  </div>
+<% end %>

--- a/app/views/sales/edit.html.erb
+++ b/app/views/sales/edit.html.erb
@@ -1,0 +1,6 @@
+<div class="container">
+  <h1><%= t('.title') %></h1>
+  <hr />
+
+  <%= render partial: 'form', locals: { sale: sale } %>
+</div>

--- a/app/views/sales/new.html.erb
+++ b/app/views/sales/new.html.erb
@@ -1,0 +1,6 @@
+<div class="container">
+  <h1><%= t('.title') %></h1>
+  <hr />
+
+  <%= render partial: 'form', locals: { sale: sale } %>
+</div>

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -115,19 +115,16 @@ SimpleForm.setup do |config|
 
   config.wrappers :vertical_multi_select,
                   tag: 'div',
-                  class: 'form-group',
+                  class: 'form-group row',
                   error_class: 'form-group-invalid',
                   valid_class: 'form-group-valid' do |b|
     b.use :html5
     b.optional :readonly
     b.use :label, class: 'form-control-label'
     b.wrapper tag: 'div',
-              class: 'd-flex' \
-                     'flex-row' \
-                     'justify-content-between' \
-                     'align-items-center' do |ba|
+              class: 'col-sm-8' do |ba|
       ba.use :input,
-             class: 'form-control mx-1',
+             class: 'form-control',
              error_class: 'is-invalid',
              valid_class: 'is-valid'
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,11 +116,21 @@ en:
     sign_out: 'Sign Out'
     unit_of_measures: 'Unit of Measures'
   sales:
+    create:
+      failure: "I'm sorry, but we were unable to create the sale"
+      success: 'Thank you, the sale has been created'
+    edit:
+      title: 'Update Sale'
     index:
       no_sales: 'No sales found'
       title: 'Sales'
+    new:
+      title: 'New Sale'
     show:
       title: 'Sale'
+    update:
+      failure: "I'm sorry, but we were unable to update the sale"
+      success: 'Thank you, the sale has been updated'
   simple_form:
     labels:
       item:
@@ -140,6 +150,8 @@ en:
       item:
         item_description: 'Item Description'
         item_number: 'Item Number'
+      sale:
+        sales_quantity: 'Sales Quantity'
       unit_of_measure:
         code: 'Unit of Measure'
       user_entry:
@@ -149,6 +161,10 @@ en:
     prompts:
       item:
         unit_of_measure: 'Base Unit of Measure'
+      sale:
+        customer: 'Please Select a Customer'
+        item: 'Please Select an Item'
+        unit_of_measure: 'Please Select a Unit of Measure'
   shared:
     buttons:
       back: 'Back'

--- a/spec/features/sales/user_creates_a_new_sale_spec.rb
+++ b/spec/features/sales/user_creates_a_new_sale_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared_scenarios'
+
+RSpec.feature 'user creates a new sale' do
+  include ActiveSupport::NumberHelper
+
+  context 'when the user has not signed in' do
+    background { visit new_sale_path }
+
+    include_examples 'user must sign in'
+  end
+
+  context 'when the details are valid' do
+    background do
+      sign_in_with(current_user.email, current_user.password)
+    end
+    given!(:current_user) { create(:user, :confirmed) }
+    given!(:customer) { create(:customer) }
+    given!(:item) { create(:item) }
+    given(:new_details) { attributes_for(:sale) }
+    given!(:unit_of_measure) { create(:unit_of_measure) }
+
+    scenario 'they see the new sale details' do
+      visit new_sale_path
+
+      select item.full_item_description, from: :sale_item_id
+      select customer.name, from: :sale_customer_id
+      select unit_of_measure.code, from: :sale_unit_of_measure_id
+      fill_in :sale_sales_date, with: new_details[:sales_date]
+      fill_in :sale_sales_quantity, with: new_details[:sales_quantity]
+
+      click_on t('shared.buttons.save')
+
+      expect(page).to have_content(t('sales.create.success'))
+
+      expect(page).to have_display_field(
+        t('activerecord.attributes.sales.customer_name'),
+        customer.name
+      )
+      expect(page).to have_display_field(
+        t('activerecord.attributes.items.item_number'),
+        item.item_number
+      )
+      expect(page).to have_display_field(
+        t('activerecord.attributes.items.item_description'),
+        item.item_description
+      )
+      expect(page).to have_display_field(
+        t('activerecord.attributes.sales.sales_date'),
+        new_details[:sales_date].strftime('%m/%d/%Y')
+      )
+      expect(page).to have_display_field(
+        t('activerecord.attributes.sales.sales_quantity'),
+        number_to_delimited(new_details[:sales_quantity], delimiter: ',')
+      )
+    end
+  end
+
+  context 'when the details are not valid' do
+    background do
+      sign_in_with(current_user.email, current_user.password)
+    end
+    given(:current_user) { create(:user, :confirmed) }
+
+    scenario 'they see the failure message' do
+      visit new_sale_path
+
+      click_on t('shared.buttons.save')
+
+      expect(page).to have_content(t('sales.create.failure'))
+    end
+  end
+end

--- a/spec/features/sales/user_updates_an_existing_sale_spec.rb
+++ b/spec/features/sales/user_updates_an_existing_sale_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared_scenarios'
+
+RSpec.feature 'user updates an existing sale' do
+  include ActiveSupport::NumberHelper
+
+  given(:current_user) { create(:user, :confirmed) }
+  given!(:customer) { create(:customer) }
+  given!(:item) { create(:item) }
+  given!(:sale) { create(:sale) }
+  given!(:unit_of_measure) { create(:unit_of_measure) }
+
+  context 'when the user has not signed in' do
+    background { visit edit_sale_path(sale) }
+
+    include_examples 'user must sign in'
+  end
+
+  context 'when the details are valid' do
+    background do
+      sign_in_with(current_user.email, current_user.password)
+    end
+    given(:new_details) { attributes_for(:sale) }
+
+    scenario 'they see the sales details have been changed' do
+      visit edit_sale_path(sale)
+
+      select item.full_item_description, from: :sale_item_id
+      select customer.name, from: :sale_customer_id
+      select unit_of_measure.code, from: :sale_unit_of_measure_id
+      fill_in :sale_sales_date, with: new_details[:sales_date]
+      fill_in :sale_sales_quantity, with: new_details[:sales_quantity]
+
+      click_on t('shared.buttons.save')
+
+      expect(page).to have_content(t('sales.update.success'))
+
+      expect(page).to have_display_field(
+        t('activerecord.attributes.sales.customer_name'),
+        customer.name
+      )
+      expect(page).to have_display_field(
+        t('activerecord.attributes.items.item_number'),
+        item.item_number
+      )
+      expect(page).to have_display_field(
+        t('activerecord.attributes.items.item_description'),
+        item.item_description
+      )
+      expect(page).to have_display_field(
+        t('activerecord.attributes.unit_of_measures.code'),
+        unit_of_measure.code
+      )
+      expect(page).to have_display_field(
+        t('activerecord.attributes.sales.sales_date'),
+        new_details[:sales_date].strftime('%m/%d/%Y')
+      )
+      expect(page).to have_display_field(
+        t('activerecord.attributes.sales.sales_quantity'),
+        number_to_delimited(
+          new_details[:sales_quantity],
+          delimiter: ','
+        )
+      )
+    end
+  end
+
+  context 'when the details are not valid' do
+    background do
+      sign_in_with(current_user.email, current_user.password)
+    end
+
+    scenario 'they see the failure message' do
+      visit edit_sale_path(sale)
+
+      fill_in :sale_sales_date, with: nil
+      fill_in :sale_sales_quantity, with: nil
+
+      click_on t('shared.buttons.save')
+
+      expect(page).to have_content(t('sales.update.failure'))
+    end
+  end
+end


### PR DESCRIPTION
Add the front end screen for sale creation and updating so
that the users may add new sales and make changes to existing
ones.

Closes #9