### PR TITLE
User may create and edit item unit of measures

### DIFF
--- a/app/controllers/items/item_unit_of_measure_controller.rb
+++ b/app/controllers/items/item_unit_of_measure_controller.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class ItemUnitOfMeasuresController < ApplicationController # :nodoc:
-  include SimpleCrudController
-end

--- a/app/controllers/items/item_unit_of_measures_controller.rb
+++ b/app/controllers/items/item_unit_of_measures_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Items
+  class ItemUnitOfMeasuresController < ApplicationController # :nodoc:
+    include SimpleCrudController
+
+    permitted_params :item_id, :unit_of_measure_id, :base_conversion
+
+    def create
+      item_unit_of_measure = ItemUnitOfMeasure.new(
+        resource_params.merge(item_id: item.id)
+      )
+
+      if item_unit_of_measure.save
+        redirect_to item, notice: t('.success')
+      else
+        flash[:alert] = t('.failure')
+        render_new(item_unit_of_measure)
+      end
+    end
+
+    def update
+      item_unit_of_measure = existing_resource
+
+      if item_unit_of_measure.update(resource_params)
+        redirect_to item_path(item_unit_of_measure.item_id),
+                    notice: t('.success')
+      else
+        flash[:alert] = t('.failure')
+        render_edit(item_unit_of_measure)
+      end
+    end
+
+    private
+
+    def item
+      @item ||= Item.find(params[:item_id])
+    end
+
+    def render_edit(item_unit_of_measure)
+      render :edit,
+             locals: {
+               item: item_unit_of_measure.item,
+               item_unit_of_measure: item_unit_of_measure
+             }
+    end
+
+    def render_new(item_unit_of_measure)
+      render :new,
+             locals: {
+               item: item,
+               item_unit_of_measure: item_unit_of_measure
+             }
+    end
+  end
+end

--- a/app/controllers/items/item_unit_of_measures_controller.rb
+++ b/app/controllers/items/item_unit_of_measures_controller.rb
@@ -20,14 +20,11 @@ module Items
     end
 
     def update
-      item_unit_of_measure = existing_resource
-
-      if item_unit_of_measure.update(resource_params)
-        redirect_to item_path(item_unit_of_measure.item_id),
-                    notice: t('.success')
+      if existing_resource.update(resource_params)
+        redirect_to item_path(existing_resource.item_id), notice: t('.success')
       else
         flash[:alert] = t('.failure')
-        render_edit(item_unit_of_measure)
+        render_edit(existing_resource)
       end
     end
 

--- a/app/views/items/item_unit_of_measures/_form.html.erb
+++ b/app/views/items/item_unit_of_measures/_form.html.erb
@@ -1,0 +1,19 @@
+<%= simple_form_for([:item, item_unit_of_measure],
+                    wrapper: :horizontal_form) do |form| %>
+  <%= form.association :unit_of_measure,
+                       label: false,
+                       label_method: :code,
+                       prompt: :translate,
+                       value_method: :id %>
+  <%= form.input :base_conversion,
+                 label: false,
+                 placeholder: :translate %>
+  <div class='float-left'>
+    <%= form.button :submit,
+                    t('shared.buttons.save'),
+                    class: 'btn btn-primary' %>
+    <%= link_to t('shared.buttons.back'),
+                item_path(item.id),
+                class: 'btn btn-outline-secondary ml-2' %>
+  </div>
+<% end %>

--- a/app/views/items/item_unit_of_measures/_index.html.erb
+++ b/app/views/items/item_unit_of_measures/_index.html.erb
@@ -1,5 +1,10 @@
 <div class="clearfix">
   <h1 class="float-left my-2"><%= t('.title') %></h1>
+  <div class="float-right mt-2">
+    <%= link_to t('shared.buttons.new'),
+                new_item_item_unit_of_measure_path(item.id),
+                class: 'btn btn-outline-primary' %>
+  </div>
 </div>
 
 <table class="table table-striped">
@@ -17,6 +22,7 @@
           )
         %>
       </th>
+      <th><%= t('shared.columns.action') %></th>
     </tr>
   </thead>
   <tbody>
@@ -29,10 +35,18 @@
                        ) %>
         </td>
         <td nowrap><%= item_unit_of_measure.base_conversion %></td>
+        <td nowrap>
+          <%= link_to '',
+                      edit_item_item_unit_of_measure_path(
+                        item.id,
+                        item_unit_of_measure.id
+                      ),
+                      class: 'btn btn-outline-secondary fas fa-edit' %>
+        </td>
       </tr>
     <% end.empty? %>
       <tr>
-        <td colspan="2"><%= t('.no_item_unit_of_measures') %></td>
+        <td colspan="3"><%= t('.no_item_unit_of_measures') %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/items/item_unit_of_measures/edit.html.erb
+++ b/app/views/items/item_unit_of_measures/edit.html.erb
@@ -1,0 +1,10 @@
+<div class="container">
+  <h1><%= t('.title') %></h1>
+  <hr />
+
+  <%= render partial: 'form',
+             locals: {
+               item: item,
+               item_unit_of_measure: item_unit_of_measure
+             } %>
+</div>

--- a/app/views/items/item_unit_of_measures/new.html.erb
+++ b/app/views/items/item_unit_of_measures/new.html.erb
@@ -1,0 +1,10 @@
+<div class="container">
+  <h1><%= t('.title') %></h1>
+  <hr />
+
+  <%= render partial: 'form',
+             locals: {
+               item: item,
+               item_unit_of_measure: item_unit_of_measure
+             } %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,9 +100,19 @@ en:
     show:
       title: 'Item'
     item_unit_of_measures:
+      create:
+        failure: "I'm sorry, but we were unable to create the item unit of measure"
+        success: 'Thank you, the item unit of measure has been created'
+      edit:
+        title: 'Update Item Unit of Measure'
       index:
         no_item_unit_of_measures: 'No unit of measures found'
         title: 'Unit of Measures'
+      new:
+        title: 'New Item Unit of Measure'
+      update:
+        failure: "I'm sorry, but we were unable to update the item unit of measure"
+        success: 'Thank you, the item unit of measure has been updated'
     update:
       failure: "I'm sorry, but we were unable to update the item"
       success: 'Thank you, the item has been updated'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,10 @@ Rails.application.routes.draw do
 
   resources :bill_of_materials, except: :destroy
   resources :customers, except: :destroy
-  resources :items, except: :destroy, shallow: true do
-    resources :item_unit_of_measures, only: %i[create edit new update]
+  resources :items, except: :destroy do
+    resources :item_unit_of_measures,
+              controller: 'items/item_unit_of_measures',
+              only: %i[create edit new update]
   end
   resources :sales, except: :destroy
   resources :unit_of_measures, except: :destroy

--- a/spec/features/items/item_unit_of_measures/user_creates_a_new_item_unit_of_measure_spec.rb
+++ b/spec/features/items/item_unit_of_measures/user_creates_a_new_item_unit_of_measure_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../shared_scenarios'
+
+RSpec.feature 'user creates a new item unit of measure' do
+  given(:current_user) { create(:user, :confirmed) }
+  given!(:item) { create(:item) }
+
+  context 'when the user has not signed in' do
+    background { visit new_item_item_unit_of_measure_path(item.id) }
+
+    include_examples 'user must sign in'
+  end
+
+  context 'when the details are valid' do
+    background do
+      sign_in_with(current_user.email, current_user.password)
+    end
+
+    given(:new_details) { attributes_for(:item_unit_of_measure) }
+    given!(:unit_of_measure) { create(:unit_of_measure) }
+
+    scenario 'they see the new item unit of measure details' do
+      visit new_item_item_unit_of_measure_path(item.id)
+
+      select unit_of_measure.code,
+             from: :item_unit_of_measure_unit_of_measure_id
+      fill_in :item_unit_of_measure_base_conversion,
+              with: new_details[:base_conversion]
+
+      click_on t('shared.buttons.save')
+
+      expect(page).to have_content(
+        t('items.item_unit_of_measures.create.success')
+      )
+
+      within("tr#item_unit_of_measure-#{item.item_unit_of_measures.last.id}") do
+        expect(page).to have_column_value(
+          t('activerecord.attributes.unit_of_measures.code'),
+          unit_of_measure.code
+        )
+        expect(page).to have_column_value(
+          t(
+            'activerecord' \
+            '.attributes' \
+            '.items' \
+            '.item_unit_of_measures' \
+            '.base_conversion'
+          ),
+          new_details[:base_conversion]
+        )
+      end
+    end
+  end
+
+  context 'when the details are not valid' do
+    background do
+      sign_in_with(current_user.email, current_user.password)
+    end
+
+    scenario 'they see the failure message' do
+      visit new_item_item_unit_of_measure_path(item.id)
+
+      click_on t('shared.buttons.save')
+
+      expect(page).to have_content(
+        t('items.item_unit_of_measures.create.failure')
+      )
+    end
+  end
+end

--- a/spec/features/items/item_unit_of_measures/user_updates_an_existing_item_unit_of_measure_spec.rb
+++ b/spec/features/items/item_unit_of_measures/user_updates_an_existing_item_unit_of_measure_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../shared_scenarios'
+
+RSpec.feature 'user updates an existing item unit of measure' do
+  given(:current_user) { create(:user, :confirmed) }
+  given!(:item_unit_of_measure) { create(:item_unit_of_measure) }
+  given!(:unit_of_measure) { create(:unit_of_measure) }
+
+  context 'when the user has not signed in' do
+    background do
+      visit edit_item_item_unit_of_measure_path(
+        item_unit_of_measure.item_id,
+        item_unit_of_measure.id
+      )
+    end
+
+    include_examples 'user must sign in'
+  end
+
+  context 'when the details are valid' do
+    background do
+      sign_in_with(current_user.email, current_user.password)
+    end
+    given!(:item) { create(:item) }
+    given(:new_details) { attributes_for(:item_unit_of_measure) }
+
+    scenario 'they see the items details have been changed' do
+      visit edit_item_item_unit_of_measure_path(
+        item_unit_of_measure.item_id,
+        item_unit_of_measure.id
+      )
+
+      select unit_of_measure.code,
+             from: :item_unit_of_measure_unit_of_measure_id
+      fill_in :item_unit_of_measure_base_conversion,
+              with: new_details[:base_conversion]
+
+      click_on t('shared.buttons.save')
+
+      expect(page).to have_content(
+        t('items.item_unit_of_measures.update.success')
+      )
+
+      within("tr#item_unit_of_measure-#{item_unit_of_measure.id}") do
+        expect(page).to have_column_value(
+          t('activerecord.attributes.unit_of_measures.code'),
+          unit_of_measure.code
+        )
+        expect(page).to have_column_value(
+          t(
+            'activerecord' \
+            '.attributes' \
+            '.items' \
+            '.item_unit_of_measures' \
+            '.base_conversion'
+          ),
+          new_details[:base_conversion]
+        )
+      end
+    end
+  end
+
+  context 'when the details are not valid' do
+    background do
+      sign_in_with(current_user.email, current_user.password)
+    end
+
+    scenario 'they see the failure message' do
+      visit edit_item_item_unit_of_measure_path(
+        item_unit_of_measure.item_id,
+        item_unit_of_measure.id
+      )
+
+      fill_in :item_unit_of_measure_base_conversion, with: nil
+
+      click_on t('shared.buttons.save')
+
+      expect(page).to have_content(
+        t('items.item_unit_of_measures.update.failure')
+      )
+    end
+  end
+end


### PR DESCRIPTION
Add the front end screen for item unit of measure creation and updating
so that the users may add new item unit of measure and make changes
to existing ones.

Closes #10